### PR TITLE
preserveSymlinks should be false as nodejs default behaviour

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ function directoryNamedResolve (id, options) {
     basedir,
     extensions,
     moduleDirectory,
-    paths
+    paths,
+    preserveSymlinks: false,
   }
 
   /* Attempt regular index.js first */

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "resolve": "^1.3.2"
+    "resolve": "^1.9.0"
   },
   "devDependencies": {
     "jest": "^19.0.2"


### PR DESCRIPTION
This PR set preserveSymlinks to false to correspond to nodejs default behavior.
nodes docs: https://nodejs.org/api/all.html#cli_preserve_symlinks