### PR TITLE
Add special-case logic to handle ts-jest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,9 @@ function directoryNamedResolve (id, options) {
   try {
     return resolve.sync(id, resolveOpts)
   } catch (e) {
-    const parsed = path.parse(id)
+    const isRelative = String(id).match(/^[.][.]?\//)
+    const resolvedId = isRelative ? path.resolve(resolveOpts.basedir, id) : id
+    const parsed = path.parse(resolvedId)
     const directoryNamedId = id + path.sep + parsed.name
     return resolve.sync(directoryNamedId, resolveOpts)
   }


### PR DESCRIPTION
In a recent project, I discovered that when I use `jest-directory-named-resolver` and `ts-jest` at the same time, the typescript resolver will send `./` or `../` as the file mapping. At that point, without this "fix," we start getting _useless_ errors from the jest engine, saying:
> Cannot find module './' from 'FileName.test.js'

After 2 days of futzing with it, I finally figured out it's that `ts-jest` can't resolve the directory-named files, so it chokes. :) I fixed it in our codebase by using `patch-package` to apply this fix, and it resolved our problems across the board with these types of imports in our jest tests - so I wanted to offer it for the community at large who might be inclined to configure things similarly.